### PR TITLE
Support more clipboard managers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ plugindir=${rofi_PLUGIN_INSTALL_DIR}/
 
 plugin_LTLIBRARIES = emoji.la
 
-dist_pkgdata_DATA = all_emojis.txt README.md screenshot.png
+dist_pkgdata_DATA = all_emojis.txt clipboard-adapter.sh README.md screenshot.png
 
 emoji_la_SOURCES=\
 		 src/emoji.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ emoji_la_SOURCES=\
 		 src/emoji.c \
 		 src/emoji_list.c \
 		 src/loader.c \
+		 src/utils.c \
 		 src/plugin.c
 
 emoji_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@

--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ emoji for "Unicorn face" being selected](screenshot.png)
 | Dependency | Version      |
 |------------|--------------|
 | rofi       | 1.4 (or git) |
-| xsel       |              |
-| xdotool    |              |
+
+**Optional dependencies**
+
+In order to actually use rofi-emoji some "adapters" need to be installed. A
+"copy adapter" is needed for the "Copy" action
+(<kbd>Shift</kbd>+<kbd>Enter</kbd>) and an "insert adapter" is needed for the
+"Insert" action (<kbd>Enter</kbd>).
+
+| Dependency   | Type           | Notes                                  |
+|--------------|----------------|----------------------------------------|
+| xsel         | Copy adapter   | For X11.                               |
+| xclip        | Copy adapter   | For X11.                               |
+| xdotool      | Insert adapter | For X11. Also a Copy adapter for X11.  |
+| wl-clipboard | Copy adapter   | For Wayland. (**Untested!**)           |
 
 ### Arch Linux
 

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Clipboard adapter for rofi-emoji.
+# Usage:
+#   clipboard-adapter.sh copy
+#     Set clipboard from STDIN
+#   clipboard-adapter.sh insert
+#     Try your best to insert this STDIN text into focused window
+#
+# Detects wayland and X and finds the appropriate tool for the current
+# environment.
+#
+# If stderr is bound to /dev/null, then the caller won't display
+# error messages. Do it manually in that case.
+
+TOOL="xsel"
+
+stderr_is_null() {
+  test /proc/self/fd/2 -ef /dev/null
+}
+
+notify() {
+  if hash notify-send 2>/dev/null; then
+    notify-send rofi-emoji "$@"
+  else
+    echo "$@" >&2
+  fi
+}
+
+show_error() {
+  if stderr_is_null; then
+    notify "$@"
+  else
+    echo "$@" >&2
+  fi
+}
+
+handle_copy() {
+  case "$TOOL" in
+    xsel)
+      exec xsel --clipboard --input
+      ;;
+    *)
+      exit 1
+  esac
+}
+
+handle_insert() {
+  case "$TOOL" in
+    xsel)
+      # Set PRIMARY clipboard…
+      xsel --primary --input
+      # …and call Shift+Insert in focused window to paste it
+      xdotool key Shift+Insert
+      ;;
+    *)
+      exit 1
+  esac
+}
+
+case "$1" in
+  copy)
+    handle_copy
+    ;;
+  insert)
+    handle_insert
+    ;;
+  *)
+    show_error "$0: Unknown command \"$1\""
+    exit 1
+esac

--- a/src/loader.c
+++ b/src/loader.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "loader.h"
+#include "utils.h"
 
 #define MAX_LINE_LENGTH 1024
 
@@ -39,45 +40,8 @@ char *scan_until(const char until, char *input, char **result) {
   return index + 1;
 }
 
-FindEmojiFileResult find_emoji_file(char **path) {
-  const char * const *data_dirs = g_get_system_data_dirs();
-  if (data_dirs == NULL) {
-    return CANNOT_DETERMINE_PATH;
-  }
-
-  // Store first path in case file cannot be found; this path will then be the
-  // path reported to the user in the error message.
-  char *first_path = NULL;
-
-  int index = 0;
-  char const *data_dir = data_dirs[index];
-  while (1) {
-    char *current_path = g_build_filename(data_dir, "rofi-emoji", "all_emojis.txt", NULL);
-    if (current_path == NULL) {
-      return CANNOT_DETERMINE_PATH;
-    }
-
-    if (g_file_test(current_path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))) {
-      *path = current_path;
-      g_free(first_path);
-      return SUCCESS;
-    }
-
-    if (first_path == NULL) {
-      first_path = current_path;
-    } else {
-      g_free(current_path);
-    }
-
-    index += 1;
-    data_dir = data_dirs[index];
-    if (data_dir == NULL) {
-      break;
-    }
-  }
-
-  *path = first_path;
-  return NOT_A_FILE;
+FindDataFileResult find_emoji_file(char **path) {
+  return find_data_file("all_emojis.txt", path);
 }
 
 EmojiList *read_emojis_from_file(char *path) {

--- a/src/loader.h
+++ b/src/loader.h
@@ -2,14 +2,9 @@
 #define LOADER_H
 
 #include "emoji_list.h"
+#include "utils.h"
 
-typedef enum {
-  SUCCESS = 1,
-  NOT_A_FILE = 0,
-  CANNOT_DETERMINE_PATH = -1
-} FindEmojiFileResult;
-
-FindEmojiFileResult find_emoji_file(char **path);
+FindDataFileResult find_emoji_file(char **path);
 EmojiList *read_emojis_from_file(char *path);
 
 #endif // LOADER_H

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -118,7 +118,7 @@ static void get_emoji( Mode *sw) {
   EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
   char *path;
 
-  FindEmojiFileResult result = find_emoji_file(&path);
+  FindDataFileResult result = find_emoji_file(&path);
   if (result == SUCCESS) {
     pd->emojis = read_emojis_from_file(path);
     pd->matcher_strings = generate_matcher_strings(pd->emojis);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,9 @@
+#include <errno.h>
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "loader.h"
 
@@ -43,4 +46,110 @@ FindDataFileResult find_data_file(char *basename, char **path) {
 
   *path = first_path;
   return NOT_A_FILE;
+}
+
+int find_clipboard_adapter(char **adapter, char **error) {
+  FindDataFileResult result = find_data_file("clipboard-adapter.sh", adapter);
+
+  if (result == SUCCESS) {
+    return TRUE;
+  } else if (result == CANNOT_DETERMINE_PATH) {
+    *error = g_strdup(
+      "Failed to load clipboard-adapter file: The path could not be determined"
+    );
+  } else if (result == NOT_A_FILE) {
+    *error = g_markup_printf_escaped(
+      "Failed to load clipboard-adapter file: <tt>%s</tt> is not a file\nAlso "\
+      "searched in every path in $XDG_DATA_DIRS.",
+      *adapter
+    );
+  } else {
+    *error = g_strdup("Unexpected error");
+  }
+
+  return FALSE;
+}
+
+int run_clipboard_adapter(
+  char *action,
+  Emoji *emoji,
+  char **error,
+  int collect_stderr
+) {
+  char *adapter;
+  int ca_result = find_clipboard_adapter(&adapter, error);
+  if (ca_result != TRUE) {
+    return FALSE;
+  }
+
+  GPid pid;
+  g_autoptr(GError) child_error = NULL;
+  gint child_stdin = -1, child_stderr = -1;
+
+  gboolean spawn_result = g_spawn_async_with_pipes(
+      /* working_directory */ NULL,
+      /* argv */ (char*[]){"/bin/sh", adapter, action, NULL},
+      /* envp */ NULL,
+      // G_SPAWN_DO_NOT_REAP_CHILD allows us to call waitpid and get the staus code.
+      /* flags */ (
+        G_SPAWN_DEFAULT |
+        G_SPAWN_STDOUT_TO_DEV_NULL |
+        G_SPAWN_DO_NOT_REAP_CHILD |
+        (collect_stderr ? 0 : G_SPAWN_STDERR_TO_DEV_NULL)
+      ),
+      /* child_setup */ NULL,
+      /* user_data */ NULL,
+      /* child_pid */ &pid,
+      /* standard_input */ &child_stdin,
+      /* standard_output */ NULL,
+      /* standard_error */ (collect_stderr ? &child_stderr : NULL),
+      /* error */ &child_error
+  );
+
+  if (child_error != NULL) {
+    *error = g_strdup_printf(
+      "Failed to run clipboard-adapter: %s",
+      child_error->message
+    );
+    return FALSE;
+  }
+
+  // Write data to the child process
+  write(child_stdin, emoji->bytes, strlen(emoji->bytes));
+  close(child_stdin);
+
+  if (collect_stderr) {
+    GString *child_error_message = g_string_new("");
+    int read_bytes;
+    char buf[128];
+    while ((read_bytes = read(child_stderr, buf, 128)) > 0) {
+      g_string_append_len(child_error_message, buf, read_bytes);
+    }
+    close(child_stderr);
+    *error = g_string_free(child_error_message, FALSE);
+  } else if (child_stderr != -1) {
+    close(child_stderr);
+  }
+
+  // Wait for it to close
+  int status = 0;
+  if (waitpid(pid, &status, WUNTRACED) == -1) {
+    *error = g_strdup_printf("Process could not be reaped: %s", strerror(errno));
+    return FALSE;
+  }
+  g_spawn_close_pid(pid);
+  status = WEXITSTATUS(status);
+
+  if (status == 0) {
+    *error = NULL;
+    return TRUE;
+  } else {
+    // if stderr was collected, then the *error was already set to the message
+    // provided by the adapter. If we're not collecting anything, put a
+    // placeholder string here instead.
+    if (!collect_stderr) {
+      *error = g_strdup_printf("clipboard-adapter exited with %d", status);
+    }
+    return FALSE;
+  }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,46 @@
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "loader.h"
+
+FindDataFileResult find_data_file(char *basename, char **path) {
+  const char * const *data_dirs = g_get_system_data_dirs();
+  if (data_dirs == NULL) {
+    return CANNOT_DETERMINE_PATH;
+  }
+
+  // Store first path in case file cannot be found; this path will then be the
+  // path reported to the user in the error message.
+  char *first_path = NULL;
+
+  int index = 0;
+  char const *data_dir = data_dirs[index];
+  while (1) {
+    char *current_path = g_build_filename(data_dir, "rofi-emoji", basename, NULL);
+    if (current_path == NULL) {
+      return CANNOT_DETERMINE_PATH;
+    }
+
+    if (g_file_test(current_path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))) {
+      *path = current_path;
+      g_free(first_path);
+      return SUCCESS;
+    }
+
+    if (first_path == NULL) {
+      first_path = current_path;
+    } else {
+      g_free(current_path);
+    }
+
+    index += 1;
+    data_dir = data_dirs[index];
+    if (data_dir == NULL) {
+      break;
+    }
+  }
+
+  *path = first_path;
+  return NOT_A_FILE;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,5 +8,7 @@ typedef enum {
 } FindDataFileResult;
 
 FindDataFileResult find_data_file(char *basename, char **path);
+int find_clipboard_adapter(char **adapter, char **error);
+int run_clipboard_adapter(char *action, Emoji *emoji, char **error, int collect_stderr);
 
 #endif // UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,12 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+typedef enum {
+  SUCCESS = 1,
+  NOT_A_FILE = 0,
+  CANNOT_DETERMINE_PATH = -1
+} FindDataFileResult;
+
+FindDataFileResult find_data_file(char *basename, char **path);
+
+#endif // UTILS_H


### PR DESCRIPTION
This PR implements support for these clipboard managers:

- `xsel` + `xdotool` (used to be hardcoded)
- `xclip` + `xdotool` (X11)
- `wl-clipboard` (`wl-copy`) (Wayland)
  - Does not support "insert" action, but falls back on normal copy.

In order to make this "intelligent" tool selection easier to build all of it has been abstracted by a shell script (in portable POSIX `sh`) that picks the best tool for the job.

It should be a lot simpler for contributors (and for me!) to patch this script when adding support for more tools.