### PR TITLE
Remove support for direct insertion of emoji

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,15 @@
+# Version 2.0 (Unreleased)
+
+Due to a lot of issues with the "insert" action on many environments, and
+inconsistent support for the primary selection, this feature has now been
+dropped and the plugin is again only doing clipboard copying.
+
+## Removed
+
+* Direct insert via <kbd>Enter</kbd>; now this key also copies the emoji to the
+  clipboard to let you paste it manually.
+* `xdotool` as a supported adapter.
+
 # Version 1.2 (2019-06-16)
 
 This is a large upgrade to the emoji data, which restores a few things that

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rofi emoji plugin
 
-An emoji selector plugin for Rofi that can either insert the emoji directly or
-copy it to the clipboard.
+An emoji selector plugin for Rofi that copies the selected emoji to the
+clipboard.
 
 ## Usage
 
@@ -11,13 +11,12 @@ Run rofi like:
 rofi -show emoji -modi emoji
 ```
 
-| Key                               | Effect                  |
-|-----------------------------------|-------------------------|
-| <kbd>Enter</kbd>                  | Insert emoji            |
-| <kbd>Shift</kbd>+<kbd>Enter</kbd> | Copy emoji to clipboard |
+| Key              | Effect                  |
+|------------------|-------------------------|
+| <kbd>Enter</kbd> | Copy emoji to clipboard |
 
-**Note:** If you change your keybinds for `kb-accept` or `kb-accept-alt`, then
-your changes will also apply here.
+**Note:** If you change your keybind for `kb-accept`, then your change will
+also apply here.
 
 ## Screenshot
 
@@ -34,17 +33,14 @@ emoji for "Unicorn face" being selected](screenshot.png)
 
 **Optional dependencies**
 
-In order to actually use rofi-emoji some "adapters" need to be installed. A
-"copy adapter" is needed for the "Copy" action
-(<kbd>Shift</kbd>+<kbd>Enter</kbd>) and an "insert adapter" is needed for the
-"Insert" action (<kbd>Enter</kbd>).
+In order to actually use rofi-emoji some "adapters" need to be installed, as
+appropriate for your environment.
 
-| Dependency   | Type           | Notes                                  |
-|--------------|----------------|----------------------------------------|
-| xsel         | Copy adapter   | For X11.                               |
-| xclip        | Copy adapter   | For X11.                               |
-| xdotool      | Insert adapter | For X11. Also a Copy adapter for X11.  |
-| wl-clipboard | Copy adapter   | For Wayland. (**Untested!**)           |
+| Dependency   | Notes                        |
+|--------------|------------------------------|
+| xsel         | For X11.                     |
+| xclip        | For X11.                     |
+| wl-clipboard | For Wayland. (**Untested!**) |
 
 ### Arch Linux
 

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -3,10 +3,8 @@
 # Usage:
 #   clipboard-adapter.sh copy
 #     Set clipboard from STDIN
-#   clipboard-adapter.sh insert
-#     Try your best to insert this STDIN text into focused window
 #
-# Detects wayland and X and finds the appropriate tool for the current
+# Detects Wayland and X and finds the appropriate tool for the current
 # environment.
 #
 # If stderr is bound to /dev/null, then the caller won't display
@@ -49,45 +47,6 @@ handle_copy() {
   esac
 }
 
-paste() {
-  if [ "$XDG_SESSION_TYPE" = wayland ]; then
-    show_error "paste is not implemented for wayland currently"
-  else
-    if hash xdotool 2>/dev/null; then
-      # …Shift+Insert pastes primary selection
-      xdotool key Shift+Insert
-    else
-      notify "xdotool must be installed for direct insert. Emoji was copied instead."
-      handle_copy "$1"
-    fi
-  fi
-}
-
-handle_insert() {
-  case "$1" in
-    xsel)
-      # Set PRIMARY clipboard…
-      xsel --primary --input
-      # …and paste in focused window
-      paste xsel
-      ;;
-    xclip)
-      # Set PRIMARY clipboard…
-      xclip -selection primary -in
-      # …and paste in focused window
-      paste xclip
-      ;;
-    wl-copy)
-      # Currently does not support inserting directly. Copy instead!
-      notify "wl-copy does not allow for inserting text directly. Emoji is copied instead."
-      handle_copy wl-copy
-      ;;
-    *)
-      show_error "$1 has no implementation for inserting yet"
-      exit 1
-  esac
-}
-
 # Print out the first argument and return true if that argument is an installed
 # command. Prints nothing and returns false if the argument is not an installed
 # command.
@@ -121,9 +80,6 @@ fi
 case "$1" in
   copy)
     handle_copy "$tool"
-    ;;
-  insert)
-    handle_insert "$tool"
     ;;
   *)
     show_error "$0: Unknown command \"$1\""


### PR DESCRIPTION
Trying to keep this feature working for all programs in all environments is a fool's errand, so it's better to cut it out than having a feature that only works some times for some people.

See #7.