### PR TITLE
Simplify clipboard adapter by not using pipes

### DIFF
--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 # Clipboard adapter for rofi-emoji.
+#
 # Usage:
-#   clipboard-adapter.sh copy
-#     Set clipboard from STDIN
+#   clipboard-adapter.sh copy "the text"
+#     Set clipboard to "the text"
 #
 # Detects Wayland and X and finds the appropriate tool for the current
 # environment.
 #
 # If stderr is bound to /dev/null, then the caller won't display
-# error messages. Do it manually in that case.
+# error messages. Do it manually in that case, for example by sending a
+# notification.
+#
+# When rofi is run from a terminal, the output both on stderr and stdout should
+# be visible to the user and makes it possible to do some debugging.
 
 stderr_is_null() {
   test /proc/self/fd/2 -ef /dev/null
@@ -33,13 +38,13 @@ show_error() {
 handle_copy() {
   case "$1" in
     xsel)
-      exec xsel --clipboard --input
+      xsel --clipboard --input
       ;;
     xclip)
-      exec xclip -selection clipboard -in
+      xclip -selection clipboard -in
       ;;
     wl-copy)
-      exec wl-copy
+      wl-copy
       ;;
     *)
       show_error "$1 has no implementation for copying yet"
@@ -79,7 +84,8 @@ fi
 
 case "$1" in
   copy)
-    handle_copy "$tool"
+    shift
+    printf "%s" "$*" | handle_copy "$tool"
     ;;
   *)
     show_error "$0: Unknown command \"$1\""

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -22,7 +22,7 @@ typedef struct {
 // Returns TRUE on success, or return FALSE on error after setting the provided
 // error buffer to a user error message.
 int copy_emoji(Emoji *emoji, char **error) {
-  return run_clipboard_adapter("copy", emoji, error, TRUE);
+  return run_clipboard_adapter("copy", emoji, error);
 }
 
 char **generate_matcher_strings(EmojiList *list) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -73,8 +73,7 @@ int find_clipboard_adapter(char **adapter, char **error) {
 int run_clipboard_adapter(
   char *action,
   Emoji *emoji,
-  char **error,
-  int collect_stderr
+  char **error
 ) {
   char *adapter;
   int ca_result = find_clipboard_adapter(&adapter, error);
@@ -82,29 +81,28 @@ int run_clipboard_adapter(
     return FALSE;
   }
 
-  GPid pid;
   g_autoptr(GError) child_error = NULL;
-  gint child_stdin = -1, child_stderr = -1;
+  int exit_status;
 
-  gboolean spawn_result = g_spawn_async_with_pipes(
+  g_spawn_sync(
       /* working_directory */ NULL,
-      /* argv */ (char*[]){"/bin/sh", adapter, action, NULL},
+      /* argv */ (char*[]){"/bin/sh", adapter, action, emoji->bytes, NULL},
       /* envp */ NULL,
       // G_SPAWN_DO_NOT_REAP_CHILD allows us to call waitpid and get the staus code.
       /* flags */ (
-        G_SPAWN_DEFAULT |
-        G_SPAWN_STDOUT_TO_DEV_NULL |
-        G_SPAWN_DO_NOT_REAP_CHILD |
-        (collect_stderr ? 0 : G_SPAWN_STDERR_TO_DEV_NULL)
+        G_SPAWN_DEFAULT
       ),
       /* child_setup */ NULL,
       /* user_data */ NULL,
-      /* child_pid */ &pid,
-      /* standard_input */ &child_stdin,
       /* standard_output */ NULL,
-      /* standard_error */ (collect_stderr ? &child_stderr : NULL),
+      /* standard_error */ NULL,
+      /* exit_status */ &exit_status,
       /* error */ &child_error
   );
+
+  if (child_error == NULL) {
+    g_spawn_check_exit_status(exit_status, &child_error);
+  }
 
   if (child_error != NULL) {
     *error = g_strdup_printf(
@@ -114,42 +112,11 @@ int run_clipboard_adapter(
     return FALSE;
   }
 
-  // Write data to the child process
-  write(child_stdin, emoji->bytes, strlen(emoji->bytes));
-  close(child_stdin);
-
-  if (collect_stderr) {
-    GString *child_error_message = g_string_new("");
-    int read_bytes;
-    char buf[128];
-    while ((read_bytes = read(child_stderr, buf, 128)) > 0) {
-      g_string_append_len(child_error_message, buf, read_bytes);
-    }
-    close(child_stderr);
-    *error = g_string_free(child_error_message, FALSE);
-  } else if (child_stderr != -1) {
-    close(child_stderr);
-  }
-
-  // Wait for it to close
-  int status = 0;
-  if (waitpid(pid, &status, WUNTRACED) == -1) {
-    *error = g_strdup_printf("Process could not be reaped: %s", strerror(errno));
-    return FALSE;
-  }
-  g_spawn_close_pid(pid);
-  status = WEXITSTATUS(status);
-
-  if (status == 0) {
+  if (exit_status == 0) {
     *error = NULL;
     return TRUE;
   } else {
-    // if stderr was collected, then the *error was already set to the message
-    // provided by the adapter. If we're not collecting anything, put a
-    // placeholder string here instead.
-    if (!collect_stderr) {
-      *error = g_strdup_printf("clipboard-adapter exited with %d", status);
-    }
+    *error = g_strdup_printf("clipboard-adapter exited with %d", exit_status);
     return FALSE;
   }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,6 @@ typedef enum {
 
 FindDataFileResult find_data_file(char *basename, char **path);
 int find_clipboard_adapter(char **adapter, char **error);
-int run_clipboard_adapter(char *action, Emoji *emoji, char **error, int collect_stderr);
+int run_clipboard_adapter(char *action, Emoji *emoji, char **error);
 
 #endif // UTILS_H


### PR DESCRIPTION
Instead the adapter takes the bytes to copy as a command line argument, and both stdout and stderr can be just inherited.

This:
  * Makes it much easier to debug the script.
  * Removes a lot of code needed for async IO in the C layer.
  * Simplifies the implementation by not needing a stderr capture.

This will hopefully fix #12.