### PR TITLE
Ensure cairo is found

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,6 @@ emoji_la_SOURCES=\
 		 src/utils.c \
 		 src/plugin.c
 
-emoji_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@
-emoji_la_LIBADD= @glib_LIBS@ @rofi_LIBS@
+emoji_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@ @cairo_CFLAGS@
+emoji_la_LIBADD= @glib_LIBS@ @rofi_LIBS@ @cairo_LIBS@
 emoji_la_LDFLAGS= -module -avoid-version

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ dnl ---------------------------------------------------------------------
 dnl PKG_CONFIG based dependencies
 dnl ---------------------------------------------------------------------
 PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 ])
+PKG_CHECK_MODULES([cairo],    [cairo])
 PKG_CHECK_MODULES([rofi],     [rofi])
 
 [rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"


### PR DESCRIPTION
Otherwise, building on NixOS fails because rofi cannot find cairo.h.

---

I was just trying to package `rofi-emoji` for NixOS (or, at least for my own personal use), but the build was failing because rofi was unable to find cairo.h. After a bit of digging (mostly looking at another plugin, [rofi-calc](https://github.com/svenstaro/rofi-calc)), I noticed that you were missing the `@cairo_{CFLAGS,LIBS}@` stuff in the Makefile! (EDIT: Was missing the `PKG_CHECK_MODULES` for cairo as well.)