### PR TITLE
Re-introduce support for inserting Emoji directly in apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ $ make
 $ sudo make install
 ```
 
+If you plan on developing the code and want to test the plugin, you can also
+run `./run-development.sh`, which will do all setup steps for you and then
+start Rofi using the locally compiled plugin and clipboard adapter script. This
+will not affect your system and does not require root.
+
 ## Emoji database
 
 When installing the emoji database (`all_emojis.txt` file) is installed in

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -2,23 +2,102 @@
 # Clipboard adapter for rofi-emoji.
 #
 # Usage:
-#   clipboard-adapter.sh copy "the text"
-#     Set clipboard to "the text"
+#   clipboard-adapter.sh copy "emoji"
+#     Set clipboard to "emoji".
+#     Example: clipboard-adapter.sh copy "😁"
+#
+#   clipboard-adapter.sh insert "emoji" "codepoints"
+#     Tries to insert the emoji in the focused application like a keypress. If
+#     insertion is not enabled, then copy instead.
+#     Example: clipboard-adapter.sh insert "😁" "U1F601"
 #
 # Detects Wayland and X and finds the appropriate tool for the current
 # environment.
 #
-# If stderr is bound to /dev/null, then the caller won't display
-# error messages. Do it manually in that case, for example by sending a
-# notification.
-#
+# If stderr is bound to /dev/null, then error messages will be emitted as
+# notifications using `notify-send` (if available).
 # When rofi is run from a terminal, the output both on stderr and stdout should
 # be visible to the user and makes it possible to do some debugging.
+#
 
+main() {
+  # Determine command
+  case "$1" in
+    insert)
+      shift
+      do_insert "$1" "$2" || do_copy "$1"
+      ;;
+    copy)
+      shift
+      do_copy "$1"
+      ;;
+    *)
+      show_error "$0: Unknown command \"$1\""
+      exit 1
+  esac
+}
+
+# Insert the emoji into the focused application.
+#
+# $1 = Emoji bytes
+# $2 = Emoji codepoints, expressed as "U<hex> U<hex>"
+do_insert() {
+  # Determine environment
+  if is_wayland; then
+    # No adapter available for this yet
+    return 1
+  else
+    # Only xdotool is supported on Xorg for now.
+    if has xdotool; then
+      xdotool_insert "$2"
+    else
+      return 1
+    fi
+  fi
+}
+
+# Copy the emoji into the clipboard.
+#
+# $1 = Emoji bytes
+do_copy() {
+  # Determine environment
+  if is_wayland; then
+    if has wl-copy; then
+      wl_copy_copy "$1"
+    else
+      show_error "No supported adapter could be found."
+      return 1
+    fi
+  else
+    if has xsel; then
+      xsel_copy "$@"
+    elif has xclip; then
+      xclip_copy "$@"
+    else
+      show_error "No supported adapter could be found."
+      return 1
+    fi
+  fi
+}
+
+# Returns successfully if the current desktop environment is running on top of
+# Wayland.
+is_wayland() {
+  [ "$XDG_SESSION_TYPE" = wayland ] || [ -n "$WAYLAND_DISPLAY" ]
+}
+
+# Returns successfully if stderr is a null device.
 stderr_is_null() {
   test /proc/self/fd/2 -ef /dev/null
 }
 
+# Returns successfully if the given command can be found on the path.
+has() {
+  hash "$1" 2>/dev/null
+}
+
+# Notify the user; try to send a notification if `notify-send` is available,
+# else fall back on plain `echo`.
 notify() {
   if hash notify-send 2>/dev/null; then
     notify-send rofi-emoji "$@"
@@ -27,6 +106,7 @@ notify() {
   fi
 }
 
+# Show an error to the user, in the best way possible.
 show_error() {
   if stderr_is_null; then
     notify "$@"
@@ -35,59 +115,31 @@ show_error() {
   fi
 }
 
-handle_copy() {
-  case "$1" in
-    xsel)
-      xsel --clipboard --input
-      ;;
-    xclip)
-      xclip -selection clipboard -in
-      ;;
-    wl-copy)
-      wl-copy
-      ;;
-    *)
-      show_error "$1 has no implementation for copying yet"
-      exit 1
-  esac
+
+############
+# Adapters #
+############
+
+# xdotool (insert only)
+xdotool_insert() {
+  xdotool key "$1" || false
 }
 
-# Print out the first argument and return true if that argument is an installed
-# command. Prints nothing and returns false if the argument is not an installed
-# command.
-try_tool() {
-  if hash "$1" 2>/dev/null; then
-    echo "$1"
-    return 0
-  else
-    return 1
-  fi
+# xsel (copy only)
+xsel_copy() {
+  printf "%s" "$1" | xsel --clipboard --input
 }
 
-# Find the best clipboard tool to use.
-determine_tool() {
-  if [ "$XDG_SESSION_TYPE" = wayland ] || [ -n "$WAYLAND_DISPLAY" ]; then
-    try_tool wl-copy ||
-      return 1
-  else
-    try_tool xsel ||
-      try_tool xclip ||
-      return 1
-  fi
+# xclip (copy only)
+xclip_copy() {
+  printf "%s" "$1" | xclip -selection clipboard -in
 }
 
-tool=$(determine_tool)
-if [ -z "$tool" ]; then
-  show_error "Could not find a supported clipboard tool installed. Install xsel."
-  exit 1
-fi
+# wl-copy (copy only)
+wl_copy_copy() {
+  printf "%s" "$1" | wl-copy
+}
 
-case "$1" in
-  copy)
-    shift
-    printf "%s" "$*" | handle_copy "$tool"
-    ;;
-  *)
-    show_error "$0: Unknown command \"$1\""
-    exit 1
-esac
+################
+
+main "$@"

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -51,12 +51,24 @@ do_insert() {
       return 1
     fi
   else
+    # This is very unreliable on Xorg; some apps supports inserting Unicode
+    # directly while others do not (Firefox being one very notable example).
+    # For this reason, always copy the character too, and then try to insert.
+    # If the user doesn't see the character appear, they should be able to
+    # paste it manually instead.
+    #
+    # Note that since a copy happens here, returning 1 will always be reundant
+    # and so this function will now always return successfully to avoid that
+    # issue.
+    do_copy "$1"
+
     # Only xdotool is supported on Xorg for now.
     if has xdotool; then
       xdotool_insert "$2"
-    else
-      return 1
     fi
+
+    # Always return successfully as a copy fallback has already been made.
+    return 0
   fi
 }
 

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -44,8 +44,12 @@ main() {
 do_insert() {
   # Determine environment
   if is_wayland; then
-    # No adapter available for this yet
-    return 1
+    # Only wtype is supported on Wayland for now.
+    if has wtype; then
+      wtype_insert "$1"
+    else
+      return 1
+    fi
   else
     # Only xdotool is supported on Xorg for now.
     if has xdotool; then
@@ -122,7 +126,12 @@ show_error() {
 
 # xdotool (insert only)
 xdotool_insert() {
-  xdotool key "$1" || false
+  xdotool key "$1"
+}
+
+# wtype (insert only)
+wtype_insert() {
+  wtype "$1"
 }
 
 # xsel (copy only)

--- a/run-development.sh
+++ b/run-development.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Run this script in order to compile the plugin and run it in Rofi. This
+# allows you to test this plugin while developing without having to `make
+# install` it on every change, which would also clobber any OS-managed
+# files if you have it installed that way.
+set -e
+
+[ ! -f configure ] && autoreconf -i
+[ ! -d build ] && mkdir build
+
+cd build
+[ ! -e .xdg ] && mkdir .xdg && ln -s ../.. .xdg/rofi-emoji
+[ ! -f config.h ] && ../configure
+
+make
+XDG_DATA_DIRS="$(pwd)/.xdg" rofi -plugin-path "$(pwd)/.libs" -modi emoji -show emoji

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -1,7 +1,7 @@
 #include <glib.h>
-
-#include <rofi/mode.h>
 #include <rofi/helper.h>
+#include <rofi/mode.h>
+
 #include <rofi/mode-private.h>
 
 #include "emoji.h"
@@ -9,6 +9,9 @@
 #include "loader.h"
 
 G_MODULE_EXPORT Mode mode;
+
+// From rofi
+void rofi_view_hide();
 
 typedef struct {
   EmojiList *emojis;
@@ -25,20 +28,30 @@ int copy_emoji(Emoji *emoji, char **error) {
   return run_clipboard_adapter("copy", emoji, error);
 }
 
+// Execute the clipboard adapter with the "insert" action to let the selected
+// emoji be inserted into the foreground window.
+//
+// NOTE: This requires Rofi to disappear/terminate.
+int insert_emoji(Emoji *emoji, char **error) {
+  // Hide rofi window before triggering the insert action so the correct window
+  // get the emoji.
+  rofi_view_hide();
+  return run_clipboard_adapter("insert", emoji, error);
+}
+
 char **generate_matcher_strings(EmojiList *list) {
-  char **strings = g_new(char*, list->length);
+  char **strings = g_new(char *, list->length);
   for (int i = 0; i < list->length; ++i) {
     Emoji *emoji = emoji_list_get(list, i);
-    strings[i] = g_strdup_printf(
-      "%s %s %s %s / %s",
-      emoji->bytes, emoji->name, emoji->keywords, emoji->group, emoji->subgroup
-    );
+    strings[i] =
+        g_strdup_printf("%s %s %s %s / %s", emoji->bytes, emoji->name,
+                        emoji->keywords, emoji->group, emoji->subgroup);
   }
   return strings;
 }
 
 static void get_emoji(Mode *sw) {
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
   char *path;
 
   FindDataFileResult result = find_emoji_file(&path);
@@ -48,14 +61,12 @@ static void get_emoji(Mode *sw) {
   } else {
     if (result == CANNOT_DETERMINE_PATH) {
       pd->message = g_strdup(
-        "Failed to load emoji file: The path could not be determined"
-      );
+          "Failed to load emoji file: The path could not be determined");
     } else if (result == NOT_A_FILE) {
       pd->message = g_markup_printf_escaped(
-        "Failed to load emoji file: <tt>%s</tt> is not a file\nAlso searched "\
-        "in every path in $XDG_DATA_DIRS.",
-        path
-      );
+          "Failed to load emoji file: <tt>%s</tt> is not a file\nAlso searched "
+          "in every path in $XDG_DATA_DIRS.",
+          path);
     }
     pd->emojis = emoji_list_new(0);
     pd->matcher_strings = NULL;
@@ -87,7 +98,7 @@ static int emoji_mode_init(Mode *sw) {
  */
 static unsigned int emoji_mode_get_num_entries(const Mode *sw) {
   const EmojiModePrivateData *pd =
-    (const EmojiModePrivateData *) mode_get_private_data(sw);
+      (const EmojiModePrivateData *)mode_get_private_data(sw);
   return pd->emojis->length;
 }
 
@@ -101,14 +112,10 @@ static unsigned int emoji_mode_get_num_entries(const Mode *sw) {
  *
  * @returns the next #ModeMode.
  */
-static ModeMode emoji_mode_result(
-  Mode *sw,
-  int mretv,
-  char **input,
-  unsigned int selected_line
-) {
+static ModeMode emoji_mode_result(Mode *sw, int mretv, char **input,
+                                  unsigned int selected_line) {
   ModeMode retv = MODE_EXIT;
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
 
   if (mretv & MENU_NEXT) {
     retv = NEXT_DIALOG;
@@ -116,14 +123,23 @@ static ModeMode emoji_mode_result(
     retv = PREVIOUS_DIALOG;
   } else if (mretv & MENU_QUICK_SWITCH) {
     retv = (mretv & MENU_LOWER_MASK);
-  } else if ((mretv & MENU_OK) ) {
+  } else if ((mretv & MENU_OK)) {
     Emoji *emoji = emoji_list_get(pd->emojis, selected_line);
 
-    if (copy_emoji(emoji, &(pd->message))) {
-      retv = MODE_EXIT;
+    if ((mretv & MENU_CUSTOM_ACTION) == MENU_CUSTOM_ACTION) {
+      // Custom action (Shift+Enter) should copy to clipboard
+      if (copy_emoji(emoji, &(pd->message))) {
+        retv = MODE_EXIT;
+      } else {
+        // Copying failed, reload dialog to show error message in pd->message.
+        retv = RELOAD_DIALOG;
+      }
     } else {
-      // Copying failed, reload dialog to show error message in pd->message.
-      retv = RELOAD_DIALOG;
+      // Normal action (Enter) should insert directly
+      insert_emoji(emoji, &(pd->message));
+      // Always exit rofi after this action completes as the window is gone
+      // anyway.
+      retv = MODE_EXIT;
     }
   } else if ((mretv & MENU_ENTRY_DELETE) == MENU_ENTRY_DELETE) {
     retv = RELOAD_DIALOG;
@@ -137,7 +153,7 @@ static ModeMode emoji_mode_result(
  * Destroy the mode
  */
 static void emoji_mode_destroy(Mode *sw) {
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
   if (pd != NULL) {
     // Free all generated matcher strings before freeing the list.
     for (int i = 0; i < pd->emojis->length; ++i) {
@@ -159,7 +175,7 @@ static void emoji_mode_destroy(Mode *sw) {
  * free).
  */
 static char *emoji_get_message(const Mode *sw) {
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
   return g_strdup(pd->message);
 }
 
@@ -167,21 +183,20 @@ static char *emoji_get_message(const Mode *sw) {
  * @param mode The mode to query
  * @param selected_line The entry to query
  * @param state The state of the entry [out]
- * @param attribute_list List of extra (pango) attribute to apply when displaying. [out][null]
+ * @param attribute_list List of extra (pango) attribute to apply when
+ * displaying. [out][null]
  * @param get_entry If the should be returned.
  *
- * Returns the string as it should be displayed for the entry and the state of how it should be displayed.
+ * Returns the string as it should be displayed for the entry and the state of
+ * how it should be displayed.
  *
- * @returns allocated new string and state when get_entry is TRUE otherwise just the state.
+ * @returns allocated new string and state when get_entry is TRUE otherwise just
+ * the state.
  */
-static char *get_display_value(
-  const Mode *sw,
-  unsigned int selected_line,
-  G_GNUC_UNUSED int *state,
-  G_GNUC_UNUSED GList **attr_list,
-  int get_entry
-) {
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
+static char *get_display_value(const Mode *sw, unsigned int selected_line,
+                               G_GNUC_UNUSED int *state,
+                               G_GNUC_UNUSED GList **attr_list, int get_entry) {
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
 
   // Rofi is not yet exporting these constants in their headers
   // *state |= MARKUP;
@@ -193,15 +208,16 @@ static char *get_display_value(
     return NULL;
   }
 
-  Emoji* emoji = emoji_list_get(pd->emojis, selected_line);
+  Emoji *emoji = emoji_list_get(pd->emojis, selected_line);
 
   if (emoji == NULL) {
     return g_strdup("n/a");
   } else {
     return g_markup_printf_escaped(
-      "%s <span weight='bold'>%s</span> <span size='small'>(%s)</span> <span size='x-small'>[%s / %s]</span>",
-      emoji->bytes, emoji->name, emoji->keywords, emoji->group, emoji->subgroup
-    );
+        "%s <span weight='bold'>%s</span> <span size='small'>(%s)</span> <span "
+        "size='x-small'>[%s / %s]</span>",
+        emoji->bytes, emoji->name, emoji->keywords, emoji->group,
+        emoji->subgroup);
   }
 }
 
@@ -214,25 +230,26 @@ static char *get_display_value(
  *
  * @param returns try when a match.
  */
-static int emoji_token_match(const Mode *sw, rofi_int_matcher **tokens, unsigned int index) {
-  EmojiModePrivateData *pd = (EmojiModePrivateData *) mode_get_private_data(sw);
-  return index < pd->emojis->length && helper_token_match(tokens, pd->matcher_strings[index]);
+static int emoji_token_match(const Mode *sw, rofi_int_matcher **tokens,
+                             unsigned int index) {
+  EmojiModePrivateData *pd = (EmojiModePrivateData *)mode_get_private_data(sw);
+  return index < pd->emojis->length &&
+         helper_token_match(tokens, pd->matcher_strings[index]);
 }
 
-
 Mode mode = {
-  .abi_version        = ABI_VERSION,
-  .name               = "emoji",
-  .cfg_name_key       = "emoji",
-  ._init              = emoji_mode_init,
-  ._get_num_entries   = emoji_mode_get_num_entries,
-  ._result            = emoji_mode_result,
-  ._destroy           = emoji_mode_destroy,
-  ._token_match       = emoji_token_match,
-  ._get_display_value = get_display_value,
-  ._get_message       = emoji_get_message,
-  ._get_completion    = NULL,
-  ._preprocess_input  = NULL,
-  .private_data       = NULL,
-  .free               = NULL,
+    .abi_version = ABI_VERSION,
+    .name = "emoji",
+    .cfg_name_key = "emoji",
+    ._init = emoji_mode_init,
+    ._get_num_entries = emoji_mode_get_num_entries,
+    ._result = emoji_mode_result,
+    ._destroy = emoji_mode_destroy,
+    ._token_match = emoji_token_match,
+    ._get_display_value = get_display_value,
+    ._get_message = emoji_get_message,
+    ._get_completion = NULL,
+    ._preprocess_input = NULL,
+    .private_data = NULL,
+    .free = NULL,
 };

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,7 +8,7 @@
 #include "loader.h"
 
 FindDataFileResult find_data_file(char *basename, char **path) {
-  const char * const *data_dirs = g_get_system_data_dirs();
+  const char *const *data_dirs = g_get_system_data_dirs();
   if (data_dirs == NULL) {
     return CANNOT_DETERMINE_PATH;
   }
@@ -20,12 +20,14 @@ FindDataFileResult find_data_file(char *basename, char **path) {
   int index = 0;
   char const *data_dir = data_dirs[index];
   while (1) {
-    char *current_path = g_build_filename(data_dir, "rofi-emoji", basename, NULL);
+    char *current_path =
+        g_build_filename(data_dir, "rofi-emoji", basename, NULL);
     if (current_path == NULL) {
       return CANNOT_DETERMINE_PATH;
     }
 
-    if (g_file_test(current_path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))) {
+    if (g_file_test(current_path,
+                    (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))) {
       *path = current_path;
       g_free(first_path);
       return SUCCESS;
@@ -54,15 +56,14 @@ int find_clipboard_adapter(char **adapter, char **error) {
   if (result == SUCCESS) {
     return TRUE;
   } else if (result == CANNOT_DETERMINE_PATH) {
-    *error = g_strdup(
-      "Failed to load clipboard-adapter file: The path could not be determined"
-    );
+    *error = g_strdup("Failed to load clipboard-adapter file: The path could "
+                      "not be determined");
   } else if (result == NOT_A_FILE) {
-    *error = g_markup_printf_escaped(
-      "Failed to load clipboard-adapter file: <tt>%s</tt> is not a file\nAlso "\
-      "searched in every path in $XDG_DATA_DIRS.",
-      *adapter
-    );
+    *error =
+        g_markup_printf_escaped("Failed to load clipboard-adapter file: "
+                                "<tt>%s</tt> is not a file\nAlso "
+                                "searched in every path in $XDG_DATA_DIRS.",
+                                *adapter);
   } else {
     *error = g_strdup("Unexpected error");
   }
@@ -70,45 +71,42 @@ int find_clipboard_adapter(char **adapter, char **error) {
   return FALSE;
 }
 
-int run_clipboard_adapter(
-  char *action,
-  Emoji *emoji,
-  char **error
-) {
+int run_clipboard_adapter(char *action, Emoji *emoji, char **error) {
   char *adapter;
   int ca_result = find_clipboard_adapter(&adapter, error);
   if (ca_result != TRUE) {
     return FALSE;
   }
 
+  gchar *codepoints = codepoints_string_for_utf8(emoji->bytes);
+
   g_autoptr(GError) child_error = NULL;
   int exit_status;
 
   g_spawn_sync(
       /* working_directory */ NULL,
-      /* argv */ (char*[]){"/bin/sh", adapter, action, emoji->bytes, NULL},
+      /* argv */
+      (char *[]){"/bin/sh", adapter, action, emoji->bytes, codepoints, NULL},
       /* envp */ NULL,
-      // G_SPAWN_DO_NOT_REAP_CHILD allows us to call waitpid and get the staus code.
-      /* flags */ (
-        G_SPAWN_DEFAULT
-      ),
+      // G_SPAWN_DO_NOT_REAP_CHILD allows us to call waitpid and get the staus
+      // code.
+      /* flags */ (G_SPAWN_DEFAULT),
       /* child_setup */ NULL,
       /* user_data */ NULL,
       /* standard_output */ NULL,
       /* standard_error */ NULL,
       /* exit_status */ &exit_status,
-      /* error */ &child_error
-  );
+      /* error */ &child_error);
+
+  g_free(codepoints);
 
   if (child_error == NULL) {
     g_spawn_check_exit_status(exit_status, &child_error);
   }
 
   if (child_error != NULL) {
-    *error = g_strdup_printf(
-      "Failed to run clipboard-adapter: %s",
-      child_error->message
-    );
+    *error = g_strdup_printf("Failed to run clipboard-adapter: %s",
+                             child_error->message);
     return FALSE;
   }
 
@@ -119,4 +117,63 @@ int run_clipboard_adapter(
     *error = g_strdup_printf("clipboard-adapter exited with %d", exit_status);
     return FALSE;
   }
+}
+
+/*
+ * Return a `gchar *` NULL-terminated list for all codepoints in the input
+ * UTF-8 string in xdotool format.
+ *
+ * For example, for the input "🇸🇪", you get
+ * {"U1F1F8", "U1F1EA", NULL} back.
+ *
+ * You need to `g_free` the items and the list yourself when you are done with
+ * it.
+ */
+gchar **codepoints_for_utf8(gchar *string) {
+  const char *codepoint_format = "U%04X";
+  // gunichar is 32-bit, which can be represented in hex using 8 characters
+  // (FFFF FFFF). With a prefix "U" and a suffix NUL byte, that gives the max
+  // length of 10.
+  const glong codepoint_max_len = 8 + 1 + 1;
+
+  gchar *valid_input = g_utf8_make_valid(string, -1);
+  glong len = g_utf8_strlen(valid_input, -1);
+  gchar **codepoints = g_malloc((len + 1) * sizeof(gchar *));
+
+  for (glong i = 0; i < len; ++i) {
+    char *substring = g_utf8_substring(valid_input, i, i + 1);
+    gunichar c = g_utf8_get_char(substring);
+    g_free(substring);
+
+    gchar *codepoint = g_malloc(codepoint_max_len);
+    g_snprintf(codepoint, codepoint_max_len, codepoint_format, c);
+    codepoints[i] = codepoint;
+  }
+
+  g_free(valid_input);
+  codepoints[len] = NULL;
+  return codepoints;
+}
+
+/*
+ * Create a `gchar *` for all codepoints in the input UTF-8 string in
+ * xdotool format separated with spaces.
+ *
+ * For example, for the input "🇸🇪", you get "U1F1 U1F1EA" back.
+ *
+ * You need to `g_free` the string after you are done with it.
+ */
+gchar *codepoints_string_for_utf8(gchar *input) {
+  gchar **codepoints = codepoints_for_utf8(input);
+
+  gchar *result = g_strjoinv(" ", codepoints);
+
+  for (int i = 0; i < g_strv_length(codepoints); ++i) {
+    if (codepoints[i] != NULL) {
+      g_free(codepoints[i]);
+    }
+  }
+  g_free(codepoints);
+
+  return result;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,9 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include "emoji.h"
+#include <glib.h>
+
 typedef enum {
   SUCCESS = 1,
   NOT_A_FILE = 0,
@@ -10,5 +13,8 @@ typedef enum {
 FindDataFileResult find_data_file(char *basename, char **path);
 int find_clipboard_adapter(char **adapter, char **error);
 int run_clipboard_adapter(char *action, Emoji *emoji, char **error);
+
+gchar **codepoints_for_utf8(gchar *string);
+gchar *codepoints_string_for_utf8(gchar *input);
 
 #endif // UTILS_H


### PR DESCRIPTION
This is a new try, following #10 which removed the previous attempt. @OJFord [showed me a seemingly working approach in a comment](https://github.com/Mange/rofi-emoji/issues/1#issuecomment-643502089) on #1.

If this works for more people it might get merged as the default behavior again.

Please test this out and post your findings in this PR to get this out quicker. :heart: :pray: 

---

How it works:

You use the plugin like always, but now when you press <kbd>Enter</kbd> the emoji will not be copied. Instead it will be inserted directly in the focused app as input.
If you are not inside X11 with `xdotool` installed or Wayland with `wtype` installed, then it will fall back to the old behavior of copying the emoji instead.

At this point the README is not updated as I want some feedback on the behavior first before I spend time doing that. If you have any questions, just let me know.

**How to install?**

Start by uninstalling any packages you've installed to run this previously (from the AUR, etc.). Then clone this repo, check out this branch and follow the installation instructions in the README.