### PR TITLE
Add insert option to menu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# `master` branch
+
+## Added
+
+* Insert option to menu mode. ([Alexander Schulz
+  (hlfbt)](https://github.com/hlfbt))
+
 # Version 3.0.1 (2022-07-24)
 
 ## Fixed

--- a/src/menu.c
+++ b/src/menu.c
@@ -3,12 +3,13 @@
 #include "formatter.h"
 #include "menu.h"
 
-const int NUM_MENU_ITEMS = 4;
+const int NUM_MENU_ITEMS = 5;
 typedef enum {
-  EMOJI_MENU_COPY = 0,
-  EMOJI_MENU_NAME = 1,
-  EMOJI_MENU_CODEPOINT = 2,
-  EMOJI_MENU_BACK = 3,
+  EMOJI_MENU_INSERT = 0,
+  EMOJI_MENU_COPY = 1,
+  EMOJI_MENU_NAME = 2,
+  EMOJI_MENU_CODEPOINT = 3,
+  EMOJI_MENU_BACK = 4,
 } MenuItem;
 
 char *emoji_menu_get_display_value(const EmojiModePrivateData *pd,
@@ -16,6 +17,8 @@ char *emoji_menu_get_display_value(const EmojiModePrivateData *pd,
   switch (line) {
   case EMOJI_MENU_BACK:
     return g_strdup("⬅ Back to search");
+  case EMOJI_MENU_INSERT:
+    return format_emoji(pd->selected_emoji, "Insert emoji ({emoji})");
   case EMOJI_MENU_COPY:
     return format_emoji(pd->selected_emoji, "Copy emoji ({emoji})");
   case EMOJI_MENU_NAME:
@@ -85,6 +88,8 @@ Action emoji_menu_select_item(EmojiModePrivateData *pd, unsigned int line) {
   switch (line) {
   case EMOJI_MENU_BACK:
     return EXIT_MENU;
+  case EMOJI_MENU_INSERT:
+    return INSERT_EMOJI;
   case EMOJI_MENU_COPY:
     return COPY_EMOJI;
   case EMOJI_MENU_NAME:

--- a/src/menu.c
+++ b/src/menu.c
@@ -5,8 +5,8 @@
 
 const int NUM_MENU_ITEMS = 5;
 typedef enum {
-  EMOJI_MENU_INSERT = 0,
-  EMOJI_MENU_COPY = 1,
+  EMOJI_MENU_PRIMARY = 0,
+  EMOJI_MENU_SECONDARY = 1,
   EMOJI_MENU_NAME = 2,
   EMOJI_MENU_CODEPOINT = 3,
   EMOJI_MENU_BACK = 4,
@@ -17,10 +17,14 @@ char *emoji_menu_get_display_value(const EmojiModePrivateData *pd,
   switch (line) {
   case EMOJI_MENU_BACK:
     return g_strdup("⬅ Back to search");
-  case EMOJI_MENU_INSERT:
-    return format_emoji(pd->selected_emoji, "Insert emoji ({emoji})");
-  case EMOJI_MENU_COPY:
-    return format_emoji(pd->selected_emoji, "Copy emoji ({emoji})");
+  case EMOJI_MENU_PRIMARY:
+    return format_emoji(pd->selected_emoji,
+                        pd->search_default_action == INSERT_EMOJI ?
+                          "Copy emoji ({emoji})" : "Insert emoji ({emoji})");
+  case EMOJI_MENU_SECONDARY:
+    return format_emoji(pd->selected_emoji,
+                        pd->search_default_action == INSERT_EMOJI ?
+                          "Insert emoji ({emoji})" : "Copy emoji ({emoji})");
   case EMOJI_MENU_NAME:
     return format_emoji(pd->selected_emoji, "Copy name (<tt>{name}</tt>)");
   case EMOJI_MENU_CODEPOINT:
@@ -88,10 +92,10 @@ Action emoji_menu_select_item(EmojiModePrivateData *pd, unsigned int line) {
   switch (line) {
   case EMOJI_MENU_BACK:
     return EXIT_MENU;
-  case EMOJI_MENU_INSERT:
-    return INSERT_EMOJI;
-  case EMOJI_MENU_COPY:
-    return COPY_EMOJI;
+  case EMOJI_MENU_PRIMARY:
+    return pd->search_default_action == INSERT_EMOJI ? COPY_EMOJI : INSERT_EMOJI;
+  case EMOJI_MENU_SECONDARY:
+    return pd->search_default_action == INSERT_EMOJI ? INSERT_EMOJI : COPY_EMOJI;
   case EMOJI_MENU_NAME:
     return COPY_NAME;
   case EMOJI_MENU_CODEPOINT:


### PR DESCRIPTION
#### Description
This adds an insert item to the menu.

Simply inserting the selected emoji was previously not possible if the configured emoji mode was copy.

The second commit of this PR also automatically swaps the copy and insert menu items based on the emoji mode.
This is to minimize the amount of keyboard presses to get to the alternative action.

I am not certain about the codestyle of the second part, so suggestions for improvements there are welcome.

#### Preview
In insert mode:
![UAHm](https://user-images.githubusercontent.com/1207056/187983504-87e0e84a-0de7-46ca-a355-6e217fad2f01.png)
In any other mode:
![7XIN](https://user-images.githubusercontent.com/1207056/187983510-1285e8a3-5c74-49c0-b6f5-36c5a4d235b6.png)
