### PR TITLE
Update to latest Rofi API

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -297,6 +297,7 @@ Mode mode = {
     .abi_version = ABI_VERSION,
     .name = "emoji",
     .cfg_name_key = "emoji",
+    .type = MODE_TYPE_SWITCHER,
     ._init = emoji_mode_init,
     ._get_num_entries = emoji_mode_get_num_entries,
     ._result = emoji_mode_result,
@@ -306,6 +307,7 @@ Mode mode = {
     ._get_message = emoji_get_message,
     ._get_completion = NULL,
     ._preprocess_input = emoji_preprocess_input,
+    ._completer_result = NULL,
     .private_data = NULL,
     .free = NULL,
 };


### PR DESCRIPTION
This updates rofi-emoji to be compatible with the latest Rofi API. The ABI version has been bumped, so packages should be rebuilt.

This specifies an explicit type for the plugin, in this case a switcher (which is the "classic" option, others are dmenu and completer).

I've also explicitly declared `_completer_result`, but this isn't used for switcher type plugins to my knowledge.