### PR TITLE
Add 'insert_no_copy' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,17 @@ The plugin adds the following command line arguments to `rofi`:
 
 #### Mode
 
-The plugin supports four modes:
+The plugin supports five modes:
 
 1. `insert` (default) - Copies the selected emoji, and then tries to insert it
    directly in the focused window.
 2. `copy` - Only copies the selected emoji to your clipboard without trying to
    insert anything.
-3. `menu` - Open the menu. Useful if you prefer to always get options when just
+3. `insert_no_copy` - Tries to insert the emoji in the focuse window, but
+   without copyiing anything.
+4. `menu` - Open the menu. Useful if you prefer to always get options when just
    pressing <kbd>Enter</kbd>.
-4. `stdout` - Write selected emoji to standard output. This is useful if you
+5. `stdout` - Write selected emoji to standard output. This is useful if you
    want to use the emoji selector inside of a shell pipeline, like Rofi's
    `-dmenu` mode. It will use the `-format` argument to customize the outputted
    text, just like `-dmenu`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The plugin supports five modes:
    directly in the focused window.
 2. `copy` - Only copies the selected emoji to your clipboard without trying to
    insert anything.
-3. `insert_no_copy` - Tries to insert the emoji in the focuse window, but
+3. `insert_no_copy` - Tries to insert the emoji in the focused window, but
    without copyiing anything.
 4. `menu` - Open the menu. Useful if you prefer to always get options when just
    pressing <kbd>Enter</kbd>.

--- a/clipboard-adapter.sh
+++ b/clipboard-adapter.sh
@@ -32,7 +32,7 @@ main() {
       command=help
       break
       ;;
-    copy | insert | help)
+    copy | insert | insert_no_copy | help)
       command="$1"
       shift
       ;;
@@ -65,6 +65,10 @@ main() {
     input="$(cat -)"
     printf "%s" "$input" | perform_copy
     printf "%s" "$input" | perform_insert
+    ;;
+  insert_no_copy)
+    # Same as 'insert' but without the copying fallback.
+    perform_insert
     ;;
   *)
     usage >&2

--- a/src/actions.c
+++ b/src/actions.c
@@ -2,6 +2,8 @@
 #include "menu.h"
 #include "utils.h"
 
+#include <stdbool.h>
+
 Emoji *get_selected_emoji(EmojiModePrivateData *pd, unsigned int line) {
   if (pd->selected_emoji != NULL) {
     return pd->selected_emoji;
@@ -33,7 +35,7 @@ ModeMode copy_emoji(EmojiModePrivateData *pd, unsigned int line) {
   return text_adapter_action("copy", pd, emoji->bytes);
 }
 
-ModeMode insert_emoji(EmojiModePrivateData *pd, unsigned int line) {
+ModeMode insert_emoji(EmojiModePrivateData *pd, unsigned int line, bool copy) {
   const Emoji *emoji = get_selected_emoji(pd, line);
   if (emoji == NULL) {
     return MODE_EXIT;
@@ -42,7 +44,8 @@ ModeMode insert_emoji(EmojiModePrivateData *pd, unsigned int line) {
   // Must hide window and give back focus to whatever app should receive the
   // insert action.
   rofi_view_hide();
-  text_adapter_action("insert", pd, emoji->bytes);
+  const char *action = copy ? "insert" : "insert_no_copy";
+  text_adapter_action(action, pd, emoji->bytes);
 
   // View is hidden and we cannot get it back again. We must exit at this point.
   return MODE_EXIT;
@@ -112,7 +115,9 @@ ModeMode perform_action(EmojiModePrivateData *pd, const Action action,
   case NOOP:
     return RELOAD_DIALOG;
   case INSERT_EMOJI:
-    return insert_emoji(pd, line);
+    return insert_emoji(pd, line, true);
+  case INSERT_NO_COPY_EMOJI:
+    return insert_emoji(pd, line, false);
   case COPY_EMOJI:
     return copy_emoji(pd, line);
   case OUTPUT_EMOJI:

--- a/src/actions.h
+++ b/src/actions.h
@@ -6,6 +6,7 @@
 typedef enum {
   NOOP,
   INSERT_EMOJI,
+  INSERT_NO_COPY_EMOJI,
   COPY_EMOJI,
   OUTPUT_EMOJI,
   COPY_NAME,

--- a/src/menu.c
+++ b/src/menu.c
@@ -7,9 +7,10 @@ const int NUM_MENU_ITEMS = 5;
 typedef enum {
   EMOJI_MENU_PRIMARY = 0,
   EMOJI_MENU_SECONDARY = 1,
-  EMOJI_MENU_NAME = 2,
-  EMOJI_MENU_CODEPOINT = 3,
-  EMOJI_MENU_BACK = 4,
+  EMOJI_MENU_INSERT_NO_COPY = 2,
+  EMOJI_MENU_NAME = 3,
+  EMOJI_MENU_CODEPOINT = 4,
+  EMOJI_MENU_BACK = 5,
 } MenuItem;
 
 char *emoji_menu_get_display_value(const EmojiModePrivateData *pd,
@@ -25,6 +26,8 @@ char *emoji_menu_get_display_value(const EmojiModePrivateData *pd,
     return format_emoji(pd->selected_emoji,
                         pd->search_default_action == INSERT_EMOJI ?
                           "Insert emoji ({emoji})" : "Copy emoji ({emoji})");
+  case EMOJI_MENU_INSERT_NO_COPY:
+    return format_emoji(pd->selected_emoji, "Insert (without copying) emoji ({emoji})");
   case EMOJI_MENU_NAME:
     return format_emoji(pd->selected_emoji, "Copy name (<tt>{name}</tt>)");
   case EMOJI_MENU_CODEPOINT:
@@ -96,6 +99,8 @@ Action emoji_menu_select_item(EmojiModePrivateData *pd, unsigned int line) {
     return pd->search_default_action == INSERT_EMOJI ? COPY_EMOJI : INSERT_EMOJI;
   case EMOJI_MENU_SECONDARY:
     return pd->search_default_action == INSERT_EMOJI ? INSERT_EMOJI : COPY_EMOJI;
+  case EMOJI_MENU_INSERT_NO_COPY:
+    return INSERT_NO_COPY_EMOJI;
   case EMOJI_MENU_NAME:
     return COPY_NAME;
   case EMOJI_MENU_CODEPOINT:


### PR DESCRIPTION
While the copy fallback is very sensible and alleviates the problems in #53, I (and so am assuming is the case for others) am fortunately not affected by it. As such, the copying of the inserted emoji acts only to pollute the state of my clipboard, which is undesirable.

This patch therefore exposes a new mode `insert_no_copy` that does exactly as expected.

Personally, I'd argue that it should be `insert`, `copy` and `insert_and_copy`, setting the default entry to `insert_and_copy`, but I can imagine there are some people who don't rely on the default (i.e. they specify `-emoji-mode`) but are still expecting the copy. This preference is weak enough to not warrant that risk.

Hoping to get this merged as I am currently using `rofi -modi emoji -show emoji -emoji-mode stdout | tr -d '\n' | wtype -` as a workaround, so looking forward to hearing your thoughts.