### PR TITLE
Expose insert_no_copy mode to rofi

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -98,6 +98,8 @@ static int emoji_mode_init(Mode *sw) {
           pd->search_default_action = INSERT_EMOJI;
         } else if (strcmp(format, "copy") == 0) {
           pd->search_default_action = COPY_EMOJI;
+        } else if (strcmp(format, "insert_no_copy") == 0) {
+          pd->search_default_action = INSERT_NO_COPY_EMOJI;
         } else if (strcmp(format, "menu") == 0) {
           pd->search_default_action = OPEN_MENU;
         } else if (strcmp(format, "stdout") == 0) {


### PR DESCRIPTION
Hello again! I forgot to add the mode to `plugin.c`. Sorry about that, this fixes so `rofi ... -emoji-mode insert_no_copy` actually works.